### PR TITLE
fix: change name in datastore transaction array [DHIS2-15001]

### DIFF
--- a/src/pages/StockConfiguration/helper.js
+++ b/src/pages/StockConfiguration/helper.js
@@ -27,7 +27,7 @@ export const populateSettingsDataStore = (settings) => ({
     itemDescription: settings.itemDescription,
     transactions: [
         {
-            sortedOrder: 0,
+            sortOrder: 0,
             distributedTo:
                 settings.distributedTo ||
                 settings.transactions[0].distributedTo,
@@ -37,7 +37,7 @@ export const populateSettingsDataStore = (settings) => ({
             transactionType: DISTRIBUTED,
         },
         {
-            sortedOrder: 1,
+            sortOrder: 1,
             stockCorrected:
                 settings.stockCorrected ||
                 settings.transactions[1].stockCorrected,
@@ -46,7 +46,7 @@ export const populateSettingsDataStore = (settings) => ({
             transactionType: CORRECTED,
         },
         {
-            sortedOrder: 2,
+            sortOrder: 2,
             stockDiscarded:
                 settings.stockDiscarded ||
                 settings.transactions[2].stockDiscarded,


### PR DESCRIPTION
**Implements** [DHIS2-15001](https://dhis2.atlassian.net/browse/DHIS2-15001)

---

### Description

Change property name from `sortedOrder` to `sortOrder`

---

### Screenshots

_change `sortedOrder` to `sortOrder` property in datastore_
![image](https://user-images.githubusercontent.com/29384664/227171379-1f28217a-4f94-4b23-a2f1-c0ff9bc7177b.png)
