### PR TITLE
fix: styles remove extra margin and align elements [DHIS2-15116]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2023-03-22T19:18:48.350Z\n"
-"PO-Revision-Date: 2023-03-22T19:18:48.350Z\n"
+"POT-Creation-Date: 2023-04-14T14:50:49.183Z\n"
+"PO-Revision-Date: 2023-04-14T14:50:49.183Z\n"
 
 msgid ""
 "You don't have access to the Use Cases App. Contact a system administrator "
@@ -146,6 +146,9 @@ msgstr "Discarded"
 
 msgid "Discarded Stock"
 msgstr "Discarded Stock"
+
+msgid "Done"
+msgstr "Done"
 
 msgid "Edit"
 msgstr "Edit"

--- a/src/components/Page/Page.js
+++ b/src/components/Page/Page.js
@@ -29,7 +29,7 @@ export const Page = ({
             <h1 className={styles.title}>{title}</h1>
             <p className={styles.desc}>{desc}</p>
         </header>
-        <div className={styles.content}>
+        <div>
             {!!loading && (
                 <div className={styles.loading}>
                     <ComponentCover translucent>

--- a/src/pages/StockConfiguration/UseCaseConfiguration/Sections.js
+++ b/src/pages/StockConfiguration/UseCaseConfiguration/Sections.js
@@ -71,7 +71,7 @@ export const Sections = ({
                     edit={edit}
                 />
 
-                <ButtonStrip end>
+                <ButtonStrip end className={styles.btnContainer}>
                     {selectedTab !== generalKey && (
                         <Button
                             small

--- a/src/pages/StockConfiguration/UseCaseConfiguration/Sections.module.css
+++ b/src/pages/StockConfiguration/UseCaseConfiguration/Sections.module.css
@@ -15,7 +15,7 @@
 .container {
     display: flex;
     flex-direction: column;
-    margin: var(--spacers-dp8) var(--spacers-dp24);
+    margin: var(--spacers-dp8) 0;
     justify-content: space-around;
     gap: var(--spacers-dp24);
 }
@@ -30,4 +30,8 @@
 
 .mb16 {
     margin-bottom: var(--spacers-dp16);
+}
+
+.btnContainer :last-child:empty {
+    margin-left: 0 !important;
 }

--- a/src/pages/StockConfiguration/UseCaseConfiguration/UseCaseConfiguration.js
+++ b/src/pages/StockConfiguration/UseCaseConfiguration/UseCaseConfiguration.js
@@ -87,7 +87,7 @@ export const UseCaseConfiguration = ({
                     <Button
                         onClick={onSave}
                         primary
-                        title={i18n.t('Save')}
+                        title={i18n.t('Done')}
                         disabled={disableSave}
                     />
                 </ButtonStrip>

--- a/src/pages/StockConfiguration/UseCaseList/Table.module.css
+++ b/src/pages/StockConfiguration/UseCaseList/Table.module.css
@@ -1,3 +1,3 @@
 .table {
-    margin: var(--spacers-dp32) var(--spacers-dp24);
+    margin: var(--spacers-dp32) 0;
 }


### PR DESCRIPTION
**Implements** [DHIS2-15116](https://dhis2.atlassian.net/browse/DHIS2-15116)

---

### Description

- Align elements like text and select fields with the section's title.
- Align the end of the Next and Prev buttons to the end of the Save button.
- Remove the outline of the main container.
- Align the List of use cases (table) with Add Program and Save buttons.
- Change the button label from Save to Done. 

---

### Screenshots

_Remove outline main container, align table to buttons_
![image](https://user-images.githubusercontent.com/29384664/232092532-fdb5838a-498d-4abd-a2a8-490da2ff19e9.png)

_Align elements to the section's title_
![image](https://user-images.githubusercontent.com/29384664/232092857-b339962d-0b9c-4e25-9f9a-37fbe41f06a1.png)
![image](https://user-images.githubusercontent.com/29384664/232093091-319fd35d-8693-4055-bbdb-33a7bc009135.png)
![image](https://user-images.githubusercontent.com/29384664/232093192-95a83248-a1a4-44fb-97d9-c0113f86388b.png)

_Align buttons and change label_
![image](https://user-images.githubusercontent.com/29384664/232093357-a80d8ebb-0dad-45c2-bfb4-b2d1043151d9.png)


[DHIS2-15116]: https://dhis2.atlassian.net/browse/DHIS2-15116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ