### PR TITLE
feat: enable disable tab and next button

### DIFF
--- a/src/pages/StockConfiguration/UseCaseConfiguration/Sections.js
+++ b/src/pages/StockConfiguration/UseCaseConfiguration/Sections.js
@@ -2,8 +2,9 @@ import i18n from '@dhis2/d2-i18n'
 import { ButtonStrip, TabBar, Tab } from '@dhis2/ui'
 import findIndex from 'lodash/findIndex'
 import PropTypes from 'prop-types'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Button } from '../../../components'
+import { validMandatoryFieldSection } from '../helper'
 import Details from './Details'
 import General from './General'
 import styles from './Sections.module.css'
@@ -17,6 +18,7 @@ export const Sections = ({
     edit,
 }) => {
     const [selectedTab, setSelectTab] = useState(0)
+    const [disabledNext, setDisable] = useState(true)
 
     const TabItems = [
         {
@@ -42,6 +44,21 @@ export const Sections = ({
 
     const CurrentSection = TabItems[selectedTab].content
 
+    const handleDisableTab = (index) =>
+        index === selectedTab
+            ? false
+            : index === 0 || index === selectedTab - 1
+            ? false
+            : index === selectedTab + 2
+            ? true
+            : disabledNext
+
+    useEffect(() => {
+        setDisable(
+            validMandatoryFieldSection(settings, TabItems[selectedTab].key)
+        )
+    }, [settings, selectedTab])
+
     return (
         <>
             <div className={styles.tabs}>
@@ -51,7 +68,7 @@ export const Sections = ({
                             key={index}
                             onClick={() => setSelectTab(index)}
                             selected={index === selectedTab}
-                            disabled={index !== selectedTab}
+                            disabled={handleDisableTab(index)}
                         >
                             {label}
                         </Tab>
@@ -84,6 +101,7 @@ export const Sections = ({
                             small
                             onClick={() => setSelectTab(selectedTab + 1)}
                             title={i18n.t('Next')}
+                            disabled={disabledNext}
                         />
                     )}
                 </ButtonStrip>

--- a/src/pages/StockConfiguration/helper.js
+++ b/src/pages/StockConfiguration/helper.js
@@ -106,3 +106,17 @@ export const getElementByProgramId = (id, list) =>
 
 export const getUnusedPrograms = (programList, programsUsed) =>
     reject(programList, (item) => find(programsUsed, { programUid: item.id }))
+
+export const propertiesSection = {
+    'general-tab': ['programUid', 'programType'],
+    'details-tab': ['itemCode', 'itemDescription', 'stockOnHand'],
+    'transactions-tab': [
+        'distributedTo',
+        'stockDistributed',
+        'stockCorrected',
+        'stockCount',
+        'stockDiscarded',
+    ],
+}
+export const validMandatoryFieldSection = (settings, section) =>
+    !validateObjectByProperty(propertiesSection[section], settings)


### PR DESCRIPTION
**Implements** [DHIS2-15209](https://dhis2.atlassian.net/browse/DHIS2-15209)

---

### Description

- Enable the Next button if all required fields are filled.
- Enable only Next Tab if all required fields of the current section are filled.

---

### Screenshots

_Next button disabled if required fields are missing_
![image](https://user-images.githubusercontent.com/29384664/234507712-d0a797f2-861d-4896-aa44-4658462ae7f4.png)

_Next button and Tab are enabled if all required fields are filled_
![image](https://user-images.githubusercontent.com/29384664/234508000-0a401288-ce7f-4196-bc24-daca76b2ec75.png)

_Next Tab is disabled if required fields are missing_
![image](https://user-images.githubusercontent.com/29384664/234508556-8121a808-c9ce-4e3e-be9b-11c4e86d0aca.png)

_Tabs are enabled if required fields are filled_
![image](https://user-images.githubusercontent.com/29384664/234509103-2d8f71e9-055b-4044-8fac-69aa4338960f.png)


[DHIS2-15209]: https://dhis2.atlassian.net/browse/DHIS2-15209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ