### PR TITLE
fix: verify system version is greater than 2.39.1 [DHIS2-16494]

### DIFF
--- a/src/auth/use-debug-info.js
+++ b/src/auth/use-debug-info.js
@@ -1,0 +1,11 @@
+import { useConfig } from '@dhis2/app-runtime'
+import { parseVersion } from '../utils'
+
+export const useDebugInfo = () => {
+    const { apiVersion, systemInfo } = useConfig()
+
+    return {
+        apiVersion: apiVersion,
+        dhis2_version: parseVersion(systemInfo?.version),
+    }
+}

--- a/src/auth/use-is-authorized.js
+++ b/src/auth/use-is-authorized.js
@@ -1,19 +1,20 @@
-import { useConfig } from '@dhis2/app-runtime'
+import semver from 'semver'
 import { useAppContext } from '../app-context'
 import { NAMESPACE } from '../shared'
+import { useDebugInfo } from './use-debug-info'
 
 const ALL = 'ALL'
-const minVersion = '39.1'
+const minVersion = '2.39.1'
 
 //TODO: define authority name reserved for this app other than ALL
 export const useIsAuthorized = () => {
-    const { apiVersion } = useConfig()
+    const { dhis2_version } = useDebugInfo()
     const { authorities, dataStore } = useAppContext()
 
     const hasAppAccessAuthorities = authorities.some(
         (authority) => authority === ALL
     )
-    const hasAppAccessVersion = apiVersion >= minVersion
+    const hasAppAccessVersion = semver.gte(dhis2_version, minVersion)
     const hasNamespace = dataStore.some((key) => key === NAMESPACE)
 
     return {

--- a/src/utils/validators/__tests__/parseVersion.test.js
+++ b/src/utils/validators/__tests__/parseVersion.test.js
@@ -1,0 +1,17 @@
+import { parseVersion } from '../parseVersion'
+
+test('2.39.5-SNAPSHOT parsed version is 2.39.5-SNAPSHOT', () => {
+    expect(parseVersion('2.39.5-SNAPSHOT')).toBe('2.39.5-SNAPSHOT')
+})
+
+test('2.39.1.1 parsed version is 2.39.1', () => {
+    expect(parseVersion('2.39.1.1')).toBe('2.39.1')
+})
+
+test('2.40 parsed version is 2.40.0', () => {
+    expect(parseVersion('2.40')).toBe('2.40.0')
+})
+
+test('2.38.0 parsed version is 2.38.0', () => {
+    expect(parseVersion('2.38.0')).toBe('2.38.0')
+})

--- a/src/utils/validators/index.js
+++ b/src/utils/validators/index.js
@@ -1,2 +1,3 @@
 export * from './isValidValue'
+export * from './parseVersion'
 export * from './validateObjectByProperty'

--- a/src/utils/validators/parseVersion.js
+++ b/src/utils/validators/parseVersion.js
@@ -1,0 +1,17 @@
+import semver from 'semver'
+
+/**
+ * Parse the input version using semver
+ */
+
+export const parseVersion = (inputVersion) => {
+    const validVersion = semver.valid(inputVersion)
+    const parsedVersion = semver.coerce(inputVersion)
+
+    if (validVersion) {
+        return validVersion
+    } else if (parsedVersion) {
+        const { major, minor, patch, prerelease } = parsedVersion
+        return `${major}.${minor}.${patch}${prerelease || ''}`
+    }
+}


### PR DESCRIPTION
**Implements** [DHIS2-16494](https://dhis2.atlassian.net/browse/DHIS2-16494)

---

### Key features

1. _Parse version number_
2. _Keep a standar version format X.Y.Z_
3. _Use system version from useConfig instead of API version_

---

### Description

Verify current system version number and authorize access to the app only if version is greater than 2.39.1

---

### Screenshots

_System version 2.39.5-SNAPSHOT_
![image](https://github.com/dhis2/use-case-configuration/assets/29384664/d1fe1215-5671-49ee-a03f-90afc4796c3d)

_System version 2.38.7-SNAPSHOT_
![image](https://github.com/dhis2/use-case-configuration/assets/29384664/1b29c840-67e5-4958-a628-df5659f0da89)


[DHIS2-16494]: https://dhis2.atlassian.net/browse/DHIS2-16494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ